### PR TITLE
test(leak): give the IP leak check the retry budget its subject already has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The IP leak test was less resilient than the code it verifies.** It made a
+  single request to `check.torproject.org`, while `tor_control.verify_tor()`
+  makes five attempts across several endpoints with a three-second backoff. One
+  TLS handshake dropped by an exit node therefore failed the Debian integration
+  job on a tree that had passed the identical job eleven minutes earlier
+  (`SSL: UNEXPECTED_EOF_WHILE_READING`). The retry budget now mirrors
+  `verify_tor`'s, and exhausting it reports a transport failure explicitly as
+  *not* a leak verdict. The endpoint list is deliberately not shared: a leak
+  test must not ask the code under test whether the code under test works.
 - **The exit-code table documented a code the CLI never returns.**
   `docs/interfaces.md` listed `2` as "invoked without root privileges", but
   `require_root()` has always raised `typer.Exit(1)`; `2` is spent by Click on

--- a/docs/web/release-notes/changelog.md
+++ b/docs/web/release-notes/changelog.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The IP leak test was less resilient than the code it verifies.** It made a
+  single request to `check.torproject.org`, while `tor_control.verify_tor()`
+  makes five attempts across several endpoints with a three-second backoff. One
+  TLS handshake dropped by an exit node therefore failed the Debian integration
+  job on a tree that had passed the identical job eleven minutes earlier
+  (`SSL: UNEXPECTED_EOF_WHILE_READING`). The retry budget now mirrors
+  `verify_tor`'s, and exhausting it reports a transport failure explicitly as
+  *not* a leak verdict. The endpoint list is deliberately not shared: a leak
+  test must not ask the code under test whether the code under test works.
 - **The exit-code table documented a code the CLI never returns.**
   `docs/interfaces.md` listed `2` as "invoked without root privileges", but
   `require_root()` has always raised `typer.Exit(1)`; `2` is spent by Click on

--- a/tests/leak/test_ip_leak.py
+++ b/tests/leak/test_ip_leak.py
@@ -12,9 +12,49 @@ from __future__ import annotations
 
 import json
 import os
+import time
 import urllib.request
 
 import pytest
+
+# The production verifier, `ttp.tor_control.verify_tor`, makes five attempts
+# across several endpoints with a three-second backoff. These tests used to make
+# a single request to a single endpoint, which left them strictly less resilient
+# than the code they exist to verify: one TLS handshake dropped by an exit node
+# failed the build where the product itself would have retried and succeeded.
+# That is exactly what happened on 2026-09-11 - `SSL: UNEXPECTED_EOF_WHILE_READING`
+# on `check.torproject.org`, on a commit whose identical tree had passed the same
+# job eleven minutes earlier.
+#
+# The retry budget below deliberately mirrors verify_tor's. The endpoint list does
+# not: a leak test must not ask the code under test whether the code under test
+# works.
+_ATTEMPTS = 5
+_BACKOFF_SECONDS = 3
+
+
+def _fetch(url: str, timeout: int) -> bytes:
+    """Fetch ``url``, retrying transient transport failures.
+
+    Re-raises the last exception if every attempt fails. A caller must read that
+    as *no verdict*, never as evidence of a leak: an endpoint we cannot reach is
+    just as consistent with TTP holding the network fail-closed, which is the
+    outcome these tests exist to confirm.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": "ttp-leak-test"})
+    last_error: Exception | None = None
+
+    for attempt in range(_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return bytes(resp.read())
+        except Exception as exc:
+            last_error = exc
+            if attempt < _ATTEMPTS - 1:
+                time.sleep(_BACKOFF_SECONDS)
+
+    assert last_error is not None
+    raise last_error
 
 
 @pytest.mark.leak
@@ -26,16 +66,14 @@ def test_ip_leak_prevention():
         pytest.skip("REAL_PUBLIC_IP environment variable not set. Skipping IP leak test.")
 
     # Request the current public IP info from Tor check API
-    req = urllib.request.Request(
-        "https://check.torproject.org/api/ip",
-        headers={"User-Agent": "ttp-leak-test"},
-    )
-
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read().decode())
+        data = json.loads(_fetch("https://check.torproject.org/api/ip", timeout=10).decode())
     except Exception as e:
-        pytest.fail(f"Failed to fetch public IP from check.torproject.org: {e}")
+        pytest.fail(
+            f"Could not reach check.torproject.org after {_ATTEMPTS} attempts: {e}. "
+            "This is a transport failure, not a leak verdict: the test could not "
+            "determine whether traffic is anonymised."
+        )
 
     current_ip = data.get("IP", "unknown")
     is_tor = data.get("IsTor", False)
@@ -57,16 +95,14 @@ def test_ipv6_leak_prevention():
     if not real_ipv6:
         pytest.skip("REAL_PUBLIC_IPV6 environment variable not set. Skipping IPv6 IP leak test.")
 
-    req = urllib.request.Request(
-        "https://ipv6.icanhazip.com",
-        headers={"User-Agent": "ttp-leak-test"},
-    )
-
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            current_ipv6 = resp.read().decode().strip()
+        current_ipv6 = _fetch("https://ipv6.icanhazip.com", timeout=15).decode().strip()
     except Exception as e:
-        pytest.fail(f"Failed to fetch public IPv6 from ipv6.icanhazip.com: {e}")
+        pytest.fail(
+            f"Could not reach ipv6.icanhazip.com after {_ATTEMPTS} attempts: {e}. "
+            "This is a transport failure, not a leak verdict: the test could not "
+            "determine whether IPv6 traffic is anonymised."
+        )
 
     assert current_ipv6, "Failed to retrieve current public IPv6 address (returned empty)."
     assert current_ipv6 != real_ipv6, f"IPv6 LEAK DETECTED! Current public IPv6 matches the unproxied IPv6: {real_ipv6}"

--- a/tests/test_leak_retry.py
+++ b/tests/test_leak_retry.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 onyks-os
+# SPDX-License-Identifier: MIT
+
+"""Coverage for the retry budget used by the offensive leak tests.
+
+`tests/leak/` is excluded from the default suite (`--ignore=tests/leak` in
+addopts) because those tests need a live TTP session and a real Tor circuit.
+That leaves their retry helper with no coverage at all: `_ATTEMPTS` could
+quietly go back to 1 and the flake it was introduced to fix would return with
+nothing to report it. So the helper is loaded by path here and exercised
+directly, in the suite that actually runs on every commit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parent / "leak" / "test_ip_leak.py"
+
+
+def _load_leak_module():
+    """Import `tests/leak/test_ip_leak.py` without collecting it as a test module."""
+    spec = importlib.util.spec_from_file_location("_ttp_leak_ip", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+leak_ip = _load_leak_module()
+
+
+def _ok_response(body: bytes) -> MagicMock:
+    """A urlopen() return value usable as a context manager."""
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = body
+    return response
+
+
+def test_fetch_retries_a_transient_failure_and_succeeds():
+    """A dropped TLS handshake must not be the final answer.
+
+    This is the 2026-09-11 failure in miniature: one `URLError` from an exit
+    node that gave up mid-handshake, on a run whose identical tree had passed
+    the same job minutes earlier.
+    """
+    attempts = [OSError("EOF occurred in violation of protocol"), _ok_response(b'{"IsTor": true}')]
+
+    with (
+        patch("urllib.request.urlopen", side_effect=attempts) as mock_urlopen,
+        patch.object(leak_ip.time, "sleep") as mock_sleep,
+    ):
+        assert leak_ip._fetch("https://check.torproject.org/api/ip", timeout=10) == b'{"IsTor": true}'
+
+    assert mock_urlopen.call_count == 2
+    assert mock_sleep.call_count == 1
+    assert mock_sleep.call_args[0][0] == leak_ip._BACKOFF_SECONDS
+
+
+def test_fetch_gives_up_after_the_full_budget_and_reraises():
+    """Exhausting the budget re-raises rather than inventing a verdict.
+
+    The caller turns this into an explicit "transport failure, not a leak
+    verdict". Swallowing it and returning something empty would let the leak
+    assertions run against nothing - a check that could not fail.
+    """
+    last = OSError("still unreachable")
+    failures = [OSError("nope")] * (leak_ip._ATTEMPTS - 1) + [last]
+
+    with (
+        patch("urllib.request.urlopen", side_effect=failures) as mock_urlopen,
+        patch.object(leak_ip.time, "sleep") as mock_sleep,
+        pytest.raises(OSError, match="still unreachable"),
+    ):
+        leak_ip._fetch("https://check.torproject.org/api/ip", timeout=10)
+
+    assert mock_urlopen.call_count == leak_ip._ATTEMPTS
+    # No sleep after the final attempt - that wait would buy nothing.
+    assert mock_sleep.call_count == leak_ip._ATTEMPTS - 1
+
+
+def test_the_retry_budget_is_not_silently_disarmed():
+    """`_ATTEMPTS = 1` would restore the original single-shot behaviour.
+
+    The two tests above would still pass with a budget of one if their fixtures
+    were adjusted to match, so the budget itself is asserted here: it exists to
+    mirror `ttp.tor_control.verify_tor`, which makes five attempts.
+    """
+    assert leak_ip._ATTEMPTS >= 5
+    assert leak_ip._BACKOFF_SECONDS >= 1


### PR DESCRIPTION
## Evidence

The Debian integration job failed on `main` and passed, unchanged, on re-run.

| Run | Tree | `test_ip_leak_prevention` |
| :-- | :-- | :-- |
| [34629423335](https://github.com/onyks-os/TransparentTorProxy/actions/runs/34629423335) (PR #24, 17:48) | same content | PASSED |
| [34629935803](https://github.com/onyks-os/TransparentTorProxy/actions/runs/34629935803) (main, 17:59) | after squash-merge | `SSL: UNEXPECTED_EOF_WHILE_READING` |
| same run, re-run unchanged | same commit | success |

## Cause

`ttp/tor_control.py:183-198` — the production verifier makes **five attempts across several endpoints with a three-second backoff**.

`tests/leak/test_ip_leak.py` — the test that exists to verify the same property made **one request to one endpoint**, ten-second timeout, no retry.

The test was strictly less resilient than the code it checks, so a single TLS handshake dropped by an exit node failed the build in a case where the product itself would have retried and succeeded.

## Change

The retry budget now mirrors `verify_tor`'s. The **endpoint list deliberately does not** — a leak test must not ask the code under test whether the code under test works.

Exhausting the budget re-raises, and the callers report it as a transport failure that yields *no verdict*:

> Could not reach check.torproject.org after 5 attempts: …. This is a transport failure, not a leak verdict: the test could not determine whether traffic is anonymised.

An endpoint we cannot reach is just as consistent with TTP holding the network fail-closed — which is the outcome these tests exist to confirm — so reporting it as a leak would be wrong in both directions. Equally, it does not `skip`: a leak test that excuses itself whenever the network is unavailable is a check that could not fail.

## Coverage for the fix itself

`tests/leak/` is excluded from the default suite (`--ignore=tests/leak` in addopts), so the new helper would have had **no coverage at all** — `_ATTEMPTS` could go back to `1` and the flake would return with nothing to report it.

`tests/test_leak_retry.py` loads the module by path and exercises the retry in the suite that runs on every commit:

- a transient failure is retried and the fetch succeeds;
- exhausting the budget re-raises the last error, with no pointless sleep after the final attempt;
- the budget itself is asserted, because the two behavioural tests would still pass with a budget of one if their fixtures were adjusted to match.

Checked against a disarmed budget (`_ATTEMPTS = 1`): two of the three fail.

481 passed, 2 skipped; `make lint` clean.

## Not addressed here

- `tests/leak/test_dns_leak.py` and `test_webrtc_leak.py` treat *any* transport failure as a pass, so they would also pass in a container with no network at all. Same defect class as #23, opposite direction — worth its own issue.
- `tests/test_cli_bypass.py::test_bypass_requires_systemd` asserts `os.path.exists` was called exactly once while patching it globally, so it counts stdlib calls too and is interpreter-sensitive (passes on 3.14.7, fails on 3.14.6). Pre-existing, unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FKToGVxTindAZG36nSi6G
