### PR TITLE
test(teardown): cover the failure paths that swallow their own errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tests for the teardown paths that swallow their own failures.** Three
+  modules whose `except` blocks log a warning and continue — the right choice,
+  since they run during teardown where raising would abandon the remaining
+  steps. What was untested is that continuing actually happens:
+  `dns.restore_dns` unmounts the overlay, hands systemd-resolved back its
+  configuration and deletes the volatile file in that order, and each step is
+  now verified to run when an earlier one fails. A teardown that stopped after
+  a failed unmount would leave `/etc/resolv.conf` bind-mounted onto a DNSPort
+  that `stop` is about to kill. `ttp/firewall/emergency.py`'s killswitch
+  handler is covered too: it fires when integrity is already lost, so a
+  swallowed exception there would report the network isolated while it is wide
+  open. `ttp/selinux.py`'s port labelling had no test at all, including the
+  `semanage port -a` → `-m` fallback that every session after the first
+  depends on. `dns.py` 77% → 100%, `selinux.py` 67% → 100%,
+  `emergency.py` 88% → 100%; floor 88% → 90%. Each test verified against a
+  mutation of the branch it covers. See
+  [#31](https://github.com/onyks-os/TransparentTorProxy/issues/31).
+
 - **Tests for every rollback branch of `ttp start`.** The four `except` blocks
   between applying the ruleset and writing the lock were entirely uncovered, and
   they are the code that decides whether a failed start leaves the host on plain

--- a/docs/web/release-notes/changelog.md
+++ b/docs/web/release-notes/changelog.md
@@ -24,6 +24,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tests for the teardown paths that swallow their own failures.** Three
+  modules whose `except` blocks log a warning and continue — the right choice,
+  since they run during teardown where raising would abandon the remaining
+  steps. What was untested is that continuing actually happens:
+  `dns.restore_dns` unmounts the overlay, hands systemd-resolved back its
+  configuration and deletes the volatile file in that order, and each step is
+  now verified to run when an earlier one fails. A teardown that stopped after
+  a failed unmount would leave `/etc/resolv.conf` bind-mounted onto a DNSPort
+  that `stop` is about to kill. `ttp/firewall/emergency.py`'s killswitch
+  handler is covered too: it fires when integrity is already lost, so a
+  swallowed exception there would report the network isolated while it is wide
+  open. `ttp/selinux.py`'s port labelling had no test at all, including the
+  `semanage port -a` → `-m` fallback that every session after the first
+  depends on. `dns.py` 77% → 100%, `selinux.py` 67% → 100%,
+  `emergency.py` 88% → 100%; floor 88% → 90%. Each test verified against a
+  mutation of the branch it covers. See
+  [#31](https://github.com/onyks-os/TransparentTorProxy/issues/31).
+
 - **Tests for every rollback branch of `ttp start`.** The four `except` blocks
   between applying the ruleset and writing the lock were entirely uncovered, and
   they are the code that decides whether a failed start leaves the host on plain

--- a/make/python.mk
+++ b/make/python.mk
@@ -60,7 +60,7 @@ lang-clean:
 # A ratchet, not a target. Raise it when you add tests; never lower it to make a
 # build pass. The floor sits just under the measured number so an accidental
 # regression is caught while a deliberate improvement is not punished.
-COV_FAIL_UNDER ?= 88
+COV_FAIL_UNDER ?= 90
 
 coverage: ## Run the test suite with a coverage report and enforce the floor
 	@$(PYTHON) -m pytest $(TEST_DIRS) --cov=$(PROJECT_PKG) --cov-report=term-missing \

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -9,9 +9,10 @@ Corresponds to TDD Section 8.3.
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -260,6 +261,314 @@ def test_restore_dns_systemd_resolved():
         dns.restore_dns({"mount_target": "/etc/resolv.conf", "systemd_resolved": True})
 
         mock_restore.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Teardown: every step must run even when an earlier one fails
+# ---------------------------------------------------------------------------
+#
+# `restore_dns` performs three things in a fixed order - unmount the overlay,
+# hand systemd-resolved back its configuration, delete the volatile file - and
+# swallows a failure in each with a `logger.warning`. Swallowing is right: it is
+# called from `stop` and from `start`'s rollback, and raising would abort the
+# rest of the teardown over a step that is already lost.
+#
+# What matters is that swallowing does not become *stopping*. The order is not
+# arbitrary: the unmount has to happen first so systemd-resolved reads the
+# restored base file. A teardown that gives up after a failed unmount therefore
+# leaves `/etc/resolv.conf` still bind-mounted onto a Tor DNSPort that `stop` is
+# about to kill - every lookup on the host failing, with no session and no
+# warning to connect it to.
+#
+# So each test below breaks one step and asserts the *later* ones still ran.
+
+
+def test_restore_dns_continues_after_a_failed_unmount(_mock_resolv_conf, caplog):
+    """A failed umount must not strand systemd-resolved or the volatile file."""
+    fake_resolv, fake_runtime = _mock_resolv_conf
+    fake_runtime.touch()
+
+    unmount_failed = subprocess.CalledProcessError(1, "umount", stderr="target is busy")
+    with (
+        patch("ttp.dns._is_ttp_mount", return_value=True),
+        patch("ttp.dns.subprocess.run", side_effect=unmount_failed),
+        patch("ttp.dns_resolved.restore_resolved") as mock_restore,
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        dns.restore_dns({"mount_target": str(fake_resolv), "systemd_resolved": True})
+
+    # Steps 2 and 3 ran regardless.
+    assert mock_restore.call_count == 1
+    assert not fake_runtime.exists()
+    assert "Failed to unmount DNS overlay" in caplog.text
+    assert "target is busy" in caplog.text
+
+
+def test_restore_dns_continues_after_a_failed_resolved_restore(_mock_resolv_conf, caplog):
+    """A systemd-resolved failure must not leak the volatile file into tmpfs."""
+    fake_resolv, fake_runtime = _mock_resolv_conf
+    fake_runtime.touch()
+
+    with (
+        patch("ttp.dns._is_ttp_mount", return_value=True),
+        patch("ttp.dns.subprocess.run", return_value=MagicMock(returncode=0)),
+        patch("ttp.dns_resolved.restore_resolved", side_effect=RuntimeError("dbus timeout")),
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        dns.restore_dns({"mount_target": str(fake_resolv), "systemd_resolved": True})
+
+    assert not fake_runtime.exists()
+    assert "Failed to restore systemd-resolved" in caplog.text
+
+
+def test_restore_dns_does_not_raise_when_the_volatile_file_cannot_be_removed(_mock_resolv_conf):
+    """The last step is cosmetic, and must not turn a teardown into an exception.
+
+    `restore_dns` is called from `start`'s StateError rollback, where an
+    exception escaping here would replace the error the operator needs to see
+    with an OSError about a file in tmpfs.
+    """
+    fake_resolv, fake_runtime = _mock_resolv_conf
+    fake_runtime.touch()
+
+    with (
+        patch("ttp.dns._is_ttp_mount", return_value=True),
+        patch("ttp.dns.subprocess.run", return_value=MagicMock(returncode=0)),
+        patch.object(Path, "unlink", side_effect=OSError("read-only file system")),
+    ):
+        dns.restore_dns({"mount_target": str(fake_resolv)})  # must not raise
+
+
+def test_restore_dns_skips_the_unmount_when_nothing_is_mounted(_mock_resolv_conf):
+    """No overlay to remove is the normal case after a crash, not an error.
+
+    The watchdog's `dns` violation is precisely "resolv.conf unmounted", so
+    `stop` routinely runs against a target that is already clear. It must skip
+    the umount rather than attempt one, and still complete steps 2 and 3.
+    """
+    fake_resolv, fake_runtime = _mock_resolv_conf
+    fake_runtime.touch()
+
+    with (
+        patch("ttp.dns._is_ttp_mount", return_value=False),
+        patch("ttp.dns.subprocess.run") as mock_run,
+        patch("ttp.dns_resolved.restore_resolved") as mock_restore,
+    ):
+        dns.restore_dns({"mount_target": str(fake_resolv), "systemd_resolved": True})
+
+    assert mock_run.call_count == 0
+    assert mock_restore.call_count == 1
+    assert not fake_runtime.exists()
+
+
+# ---------------------------------------------------------------------------
+# apply_dns rolls back its own partial state
+# ---------------------------------------------------------------------------
+#
+# This is the property `ttp start`'s rollback branches are built on: neither the
+# DNSError branch nor the unexpected-DNS branch calls `restore_dns`, because
+# `apply_dns` is expected to have already undone whatever it managed to do. That
+# expectation was asserted in a docstring and nowhere else (#31); these tests
+# are what make it a contract.
+
+
+def test_apply_dns_rolls_back_its_resolved_dropin_when_the_mount_fails(_mock_resolv_conf):
+    """A drop-in written before a failed mount must not outlive the failure.
+
+    `apply_resolved` runs first and restarts systemd-resolved pointed at Tor's
+    DNSPort. If the bind mount then fails, `start` gives up - and if the drop-in
+    survived, the host would resolve through a DNSPort with no session behind it
+    and nothing in the lock file to explain it.
+    """
+
+    def run(args, **kwargs):
+        if resolve("mount") in args:
+            raise subprocess.CalledProcessError(1, "mount", stderr="not a directory")
+        return MagicMock(returncode=0)
+
+    with (
+        patch("ttp.dns.subprocess.run", side_effect=run),
+        patch("ttp.dns_resolved.apply_resolved", return_value=True),
+        patch("ttp.dns_resolved.restore_resolved") as mock_restore,
+        pytest.raises(DNSError),
+    ):
+        dns.apply_dns("eth0")
+
+    assert mock_restore.call_count == 1
+
+
+def test_apply_dns_does_not_roll_back_a_dropin_it_never_wrote(_mock_resolv_conf):
+    """`apply_resolved` returning False means there is nothing to undo.
+
+    Calling `restore_resolved` anyway would restart systemd-resolved on a host
+    where TTP never touched it - a side effect from a command that failed.
+    """
+
+    def run(args, **kwargs):
+        if resolve("mount") in args:
+            raise subprocess.CalledProcessError(1, "mount", stderr="not a directory")
+        return MagicMock(returncode=0)
+
+    with (
+        patch("ttp.dns.subprocess.run", side_effect=run),
+        patch("ttp.dns_resolved.apply_resolved", return_value=False),
+        patch("ttp.dns_resolved.restore_resolved") as mock_restore,
+        pytest.raises(DNSError),
+    ):
+        dns.apply_dns("eth0")
+
+    assert mock_restore.call_count == 0
+
+
+def test_apply_dns_reports_the_mount_failure_even_if_its_own_rollback_fails(_mock_resolv_conf):
+    """The rollback's own failure must not replace the error that caused it.
+
+    `apply_dns` wraps its cleanup in a bare `except Exception: pass` for exactly
+    this reason. The caller is `start`, which needs the DNS failure to report;
+    a dbus error from the cleanup would tell it nothing useful and hide the
+    cause.
+    """
+
+    def run(args, **kwargs):
+        if resolve("mount") in args:
+            raise subprocess.CalledProcessError(1, "mount", stderr="not a directory")
+        return MagicMock(returncode=0)
+
+    with (
+        patch("ttp.dns.subprocess.run", side_effect=run),
+        patch("ttp.dns_resolved.apply_resolved", return_value=True),
+        patch("ttp.dns_resolved.restore_resolved", side_effect=RuntimeError("dbus timeout")),
+        pytest.raises(DNSError, match="Command failed: mount"),
+    ):
+        dns.apply_dns("eth0")
+
+
+def test_apply_dns_wraps_an_unexpected_failure_as_dnserror(_mock_resolv_conf):
+    """Anything that is not a CalledProcessError still arrives as DNSError.
+
+    `start` catches `DNSError` and a generic `Exception` in two separate
+    branches that happen to tear down identically today. They are only
+    guaranteed to stay identical for failures that reach the generic one, so
+    everything `apply_dns` can foresee is converted here rather than left to
+    chance.
+    """
+    with (
+        patch("ttp.dns_resolved.apply_resolved", return_value=False),
+        patch.object(Path, "write_text", side_effect=PermissionError("read-only /run")),
+        pytest.raises(DNSError, match="Failed to apply DNS configuration"),
+    ):
+        dns.apply_dns("eth0")
+
+
+def test_restore_dns_with_no_backup_is_a_no_op(_mock_resolv_conf):
+    """A falsy backup means there was never a session, so there is nothing to undo.
+
+    This is the guard that makes `restore_dns(None)` silent, and the reason
+    `start`'s StateError rollback has to pass the real backup dict rather than
+    `None` - a detail that is otherwise invisible and is asserted from the other
+    side in `tests/test_cli_start.py`.
+    """
+    _, fake_runtime = _mock_resolv_conf
+    fake_runtime.touch()
+
+    with (
+        patch("ttp.dns._is_ttp_mount") as mock_is_mount,
+        patch("ttp.dns.subprocess.run") as mock_run,
+        patch("ttp.dns_resolved.restore_resolved") as mock_restore,
+    ):
+        dns.restore_dns(None)
+        dns.restore_dns({})
+
+    assert mock_is_mount.call_count == 0
+    assert mock_run.call_count == 0
+    assert mock_restore.call_count == 0
+    # Notably it does *not* clean up the volatile file either.
+    assert fake_runtime.exists()
+
+
+# Interface detection
+
+
+def test_detect_active_interface_reads_the_default_route():
+    """The interface name comes from `ip route show default`, not a guess.
+
+    It decides which interface `apply_dns` configures, so the fallback below is
+    a last resort rather than an equivalent outcome.
+    """
+    with patch("ttp.dns.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="default via 192.168.1.1 dev wlp3s0 proto dhcp metric 600",
+        )
+        assert dns.detect_active_interface() == "wlp3s0"
+
+    assert mock_run.call_args.args[0][:4] == [resolve("ip"), "route", "show", "default"]
+
+
+def test_detect_active_interface_falls_back_when_there_is_no_default_route():
+    """No route, or `ip` failing outright, must not raise - `start` would abort.
+
+    "eth0" is a guess, and a wrong guess means the DNS overlay is applied to an
+    interface that is not carrying the traffic. That is a real limitation, but
+    an exception here would be worse: it would fail the session before any rule
+    is applied, which is the one start path that leaves the host in cleartext.
+    """
+    with patch("ttp.dns.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        assert dns.detect_active_interface() == "eth0"
+
+    with patch("ttp.dns.subprocess.run", side_effect=subprocess.CalledProcessError(2, "ip")):
+        assert dns.detect_active_interface() == "eth0"
+
+
+# Mount introspection
+
+
+def test_is_ttp_mount_recognises_a_ttp_overlay(tmp_path: Path):
+    """Only a mount whose line mentions ttp counts, so foreign mounts are left alone.
+
+    `restore_dns` unmounts whatever this returns True for. Matching on the mount
+    point alone would make TTP unmount a resolv.conf overlay installed by
+    something else - a VPN client, a container runtime - on teardown.
+    """
+    mountinfo = (
+        "25 30 0:22 / /proc rw,nosuid shared:5 - proc proc rw\n"
+        "31 30 0:24 /ttp/resolv.conf /etc/resolv.conf rw - tmpfs ttp-run rw\n"
+    )
+    with patch("builtins.open", mock_open(read_data=mountinfo)):
+        assert dns._is_ttp_mount("/etc/resolv.conf") is True
+        assert dns._is_ttp_mount("/proc") is False
+        assert dns._is_ttp_mount("/etc/nsswitch.conf") is False
+
+
+def test_is_ttp_mount_is_false_when_mountinfo_cannot_be_read():
+    """An unreadable /proc must answer "not mounted", never raise.
+
+    Both callers treat True as "there is an overlay to remove". Answering False
+    means `restore_dns` skips an unmount it might have needed, which is a
+    leftover; raising would abort the whole teardown, which is worse.
+    """
+    with patch("builtins.open", side_effect=PermissionError("no /proc")):
+        assert dns._is_ttp_mount("/etc/resolv.conf") is False
+
+
+def test_clear_stale_mounts_warns_when_the_stack_will_not_clear(caplog):
+    """A mount stack that survives 100 unmounts is reported, not silently accepted.
+
+    `apply_dns` calls this before mounting its own overlay. If the stack is
+    still there afterwards, the new mount goes on top of unknown layers and the
+    matching unmount on teardown will expose one of them rather than the
+    original file - so the operator has to be told.
+    """
+    with (
+        patch("ttp.dns._is_ttp_mount", return_value=True),
+        patch("ttp.dns.subprocess.run") as mock_run,
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        dns._clear_stale_mounts("/etc/resolv.conf")
+
+    assert mock_run.call_count == 100
+    assert "Could not fully clear stale TTP mounts" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -678,3 +678,58 @@ class TestEmergencyTeardown:
             apply_active_socket_slaughter()
 
         assert "Active socket slaughter FAILED" in caplog.text
+
+    # The killswitch's *own* error handler. Every other test in this class checks
+    # what happens when a teardown step fails; these two check what happens when
+    # the last resort fails.
+    #
+    # The killswitch fires when the watchdog has already concluded integrity is
+    # lost, so the only remaining question is whether the caller finds out. A
+    # swallowed exception here is the worst failure mode TTP has: the FSM would
+    # transition to `killswitch` and report the network isolated while it is
+    # still wide open. That is fail-OPEN reported as fail-closed.
+
+    @patch("ttp.firewall.emergency._apply_table_atomically")
+    def test_killswitch_failure_reaches_the_caller_unwrapped(self, mock_apply, caplog):
+        """A FirewallError from the transaction propagates as itself.
+
+        `_apply_table_atomically` already raises `FirewallError` with the nft
+        stderr in it. Re-wrapping would bury that message one exception deeper
+        for no gain, so the handler re-raises instead - and the operator, who is
+        being told the network could not be isolated, gets the reason nft gave.
+        """
+        from ttp.firewall import apply_emergency_killswitch
+
+        original = FirewallError("nft: Operation not permitted")
+        mock_apply.side_effect = original
+
+        with caplog.at_level(logging.ERROR, logger="ttp"), pytest.raises(FirewallError) as exc_info:
+            apply_emergency_killswitch()
+
+        # The same object, not a copy wrapping it.
+        assert exc_info.value is original
+        assert "Failed to apply emergency killswitch" in caplog.text
+        assert "Operation not permitted" in caplog.text
+
+    @patch("ttp.firewall.emergency._apply_table_atomically")
+    def test_killswitch_never_swallows_an_unexpected_failure(self, mock_apply, caplog):
+        """Anything the transaction did not anticipate is still raised, as FirewallError.
+
+        An `OSError` - nft missing, /run unwritable, the tmpfs full - is not
+        something `_apply_table_atomically` converts, so without the wrap it
+        would escape as a bare OSError that callers catching `FirewallError`
+        would miss entirely. The FSM is one such caller.
+
+        The cause chain is preserved so the original is still diagnosable.
+        """
+        from ttp.firewall import apply_emergency_killswitch
+
+        root_cause = OSError("[Errno 28] No space left on device")
+        mock_apply.side_effect = root_cause
+
+        with caplog.at_level(logging.ERROR, logger="ttp"), pytest.raises(FirewallError) as exc_info:
+            apply_emergency_killswitch()
+
+        assert exc_info.value.__cause__ is root_cause
+        assert "No space left on device" in str(exc_info.value)
+        assert "Failed to apply emergency killswitch" in caplog.text

--- a/tests/test_selinux_strategy.py
+++ b/tests/test_selinux_strategy.py
@@ -9,6 +9,8 @@ the installation/removal logic for the custom policy module.
 
 from __future__ import annotations
 
+import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -20,8 +22,10 @@ from ttp.tor_detect import (
     is_selinux_module_installed,
 )
 from ttp.tor_install import (
+    label_ports_selinux,
     remove_selinux_module,
     setup_selinux_if_needed,
+    unlabel_ports_selinux,
 )
 
 
@@ -190,3 +194,278 @@ def test_remove_selinux_module_calls_semodule_r():
     ):
         remove_selinux_module()
         mock_run.assert_any_call([resolve("semodule"), "-r", "ttp_tor_policy"], check=True)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic port labelling
+# ---------------------------------------------------------------------------
+#
+# `label_ports_selinux` had no test at all, and it is not cosmetic: on an
+# enforcing host, Tor cannot bind a TransPort or DNSPort that is not labelled
+# `tor_port_t`. If this function silently does nothing, `ttp start` applies the
+# full ruleset - redirecting all traffic at a port Tor could never open - and
+# then fails verification. That is the fail-closed-but-broken state exit code 3
+# exists to report, reached from a policy detail rather than a network fault.
+#
+# Everything here therefore has to degrade rather than raise: `start` calls it
+# through `start_tor_service`, where an exception would abort the session before
+# any rule is applied, leaving the host in cleartext.
+
+
+def test_label_ports_is_a_no_op_without_semanage():
+    """No semanage means no SELinux port management, and no crash either.
+
+    Debian has no `semanage` and does not need one. The function has to be a
+    silent no-op there, not an error, because the same code path runs on every
+    distribution.
+    """
+    with (
+        patch("ttp.selinux.resolve_optional", return_value=None),
+        patch("ttp.selinux.subprocess.run") as mock_run,
+    ):
+        label_ports_selinux(9041, 9054)
+
+    assert mock_run.call_count == 0
+
+
+def test_label_ports_labels_both_the_transport_and_dns_ports():
+    """The TCP TransPort and the UDP DNSPort are two separate labels.
+
+    Getting the protocol wrong is the interesting failure: `-p tcp` on the
+    DNSPort would leave UDP/9054 unlabelled, so DNS redirection would land on a
+    port Tor cannot bind while TCP traffic worked - a DNS-only leak path that
+    looks like a working session.
+    """
+    with (
+        patch("ttp.selinux.resolve_optional", return_value="/usr/sbin/semanage"),
+        patch("ttp.selinux.subprocess.run") as mock_run,
+    ):
+        label_ports_selinux(9041, 9054)
+
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0] == [
+        "/usr/sbin/semanage",
+        "port",
+        "-a",
+        "-t",
+        "tor_port_t",
+        "-p",
+        "tcp",
+        "9041",
+    ]
+    assert mock_run.call_args_list[1].args[0] == [
+        "/usr/sbin/semanage",
+        "port",
+        "-a",
+        "-t",
+        "tor_port_t",
+        "-p",
+        "udp",
+        "9054",
+    ]
+
+
+def test_label_ports_modifies_a_label_that_already_exists():
+    """`semanage port -a` fails when the mapping is already there; `-m` is the fix.
+
+    This is the common case, not an edge one: the label survives a reboot, so
+    the second `ttp start` on the same ports always takes this path. Without the
+    fallback, every session after the first would run with the `-a` failure
+    swallowed and the label left owned by whatever set it last.
+    """
+    calls = []
+
+    def run(args, **kwargs):
+        calls.append(args)
+        if "-a" in args:
+            raise subprocess.CalledProcessError(1, "semanage", stderr=b"port already defined")
+        return MagicMock(returncode=0)
+
+    with (
+        patch("ttp.selinux.resolve_optional", return_value="/usr/sbin/semanage"),
+        patch("ttp.selinux.subprocess.run", side_effect=run),
+    ):
+        label_ports_selinux(9041, 9054)
+
+    # Four calls: -a then -m, for each of the two ports.
+    assert len(calls) == 4
+    assert calls[1] == ["/usr/sbin/semanage", "port", "-m", "-t", "tor_port_t", "-p", "tcp", "9041"]
+    assert calls[3] == ["/usr/sbin/semanage", "port", "-m", "-t", "tor_port_t", "-p", "udp", "9054"]
+
+
+def test_label_ports_still_attempts_the_second_port_after_the_first_fails(caplog):
+    """One unlabellable port must not cost the other its label.
+
+    The `try` is inside the loop, which is what makes this true. If it wrapped
+    the loop instead, a TransPort that could not be labelled would silently
+    skip the DNSPort - and DNS is the leak path that matters most, since a
+    failed TCP redirect is visible immediately while a failed DNS one is not.
+    """
+    with (
+        patch("ttp.selinux.resolve_optional", return_value="/usr/sbin/semanage"),
+        patch(
+            "ttp.selinux.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "semanage", stderr=b"permission denied"),
+        ) as mock_run,
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        label_ports_selinux(9041, 9054)
+
+    # -a and -m attempted for both ports, and both failures reported.
+    assert mock_run.call_count == 4
+    assert "Failed to label port 9041/tcp" in caplog.text
+    assert "Failed to label port 9054/udp" in caplog.text
+
+
+def test_unlabel_ports_is_a_no_op_without_semanage():
+    """Teardown on a host with no semanage must not raise.
+
+    `do_stop` calls this between stopping Tor and destroying the rules. An
+    exception here would abort the teardown with the ruleset still loaded.
+    """
+    with (
+        patch("ttp.selinux.resolve_optional", return_value=None),
+        patch("ttp.selinux.subprocess.run") as mock_run,
+    ):
+        unlabel_ports_selinux(9041, 9054)
+
+    assert mock_run.call_count == 0
+
+
+def test_unlabel_ports_removes_both_labels():
+    with (
+        patch("ttp.selinux.resolve_optional", return_value="/usr/sbin/semanage"),
+        patch("ttp.selinux.subprocess.run") as mock_run,
+    ):
+        unlabel_ports_selinux(9041, 9054)
+
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0] == ["/usr/sbin/semanage", "port", "-d", "-p", "tcp", "9041"]
+    assert mock_run.call_args_list[1].args[0] == ["/usr/sbin/semanage", "port", "-d", "-p", "udp", "9054"]
+
+
+def test_unlabel_ports_swallows_a_failed_removal_and_continues():
+    """A label that was never added is the expected case, not an error.
+
+    `do_stop` runs this unconditionally, including after a `start` that failed
+    before `label_ports_selinux` ran. `semanage port -d` on a mapping that does
+    not exist exits non-zero, and that has to stay silent - but the second port
+    must still be attempted, which is why the `try` is inside the loop here too.
+    """
+    with (
+        patch("ttp.selinux.resolve_optional", return_value="/usr/sbin/semanage"),
+        patch(
+            "ttp.selinux.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "semanage", stderr=b"not defined"),
+        ) as mock_run,
+    ):
+        unlabel_ports_selinux(9041, 9054)  # must not raise
+
+    assert mock_run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Policy module install and removal: every failure degrades
+# ---------------------------------------------------------------------------
+
+
+def test_setup_selinux_skips_when_the_policy_source_is_missing(caplog):
+    """A packaging fault must be reported, not crash `ttp start`.
+
+    The `.te` file ships inside the wheel, so its absence means a broken
+    install. Tor will then fail to bind its ports on an enforcing host, and the
+    warning here is the only thing connecting that to the real cause.
+    """
+    with (
+        patch("ttp.tor_detect.is_fedora_family", return_value=True),
+        patch("ttp.tor_detect.is_selinux_enforcing", return_value=True),
+        patch("ttp.tor_detect.is_selinux_module_installed", return_value=False),
+        patch.object(Path, "exists", return_value=False),
+        patch("ttp.selinux.subprocess.run") as mock_run,
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        setup_selinux_if_needed()
+
+    assert mock_run.call_count == 0
+    assert "SELinux policy source missing" in caplog.text
+
+
+def test_setup_selinux_skips_when_the_policy_toolchain_is_absent(caplog):
+    """checkpolicy/policycoreutils missing is a supported configuration.
+
+    An enforcing host without the compiler is not TTP's problem to solve, but
+    it is TTP's job to say so and carry on rather than abort the session.
+    """
+    with (
+        patch("ttp.tor_detect.is_fedora_family", return_value=True),
+        patch("ttp.tor_detect.is_selinux_enforcing", return_value=True),
+        patch("ttp.tor_detect.is_selinux_module_installed", return_value=False),
+        patch.object(Path, "exists", return_value=True),
+        patch("ttp.selinux.resolve_optional", return_value=None),
+        patch("ttp.selinux.subprocess.run") as mock_run,
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        setup_selinux_if_needed()
+
+    assert mock_run.call_count == 0
+    assert "Cannot compile SELinux policy" in caplog.text
+
+
+def test_setup_selinux_warns_but_does_not_raise_when_compilation_fails(caplog):
+    """A failed compile leaves Tor unable to bind, and must say so without raising.
+
+    This runs inside `setup_managed_tor`, before any firewall rule exists.
+    Raising would abort `start` on the one path that leaves the host in plain
+    cleartext - trading a session that might still work for a definite
+    non-session, over a policy module.
+    """
+    with (
+        patch("ttp.tor_detect.is_fedora_family", return_value=True),
+        patch("ttp.tor_detect.is_selinux_enforcing", return_value=True),
+        patch("ttp.tor_detect.is_selinux_module_installed", return_value=False),
+        patch.object(Path, "exists", return_value=True),
+        _stub_lookup("/usr/bin/cmd"),
+        patch(
+            "ttp.selinux.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "checkmodule", stderr=b"syntax error"),
+        ),
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        setup_selinux_if_needed()  # must not raise
+
+    assert "SELinux policy installation failed" in caplog.text
+
+
+def test_remove_selinux_module_is_a_no_op_without_semodule():
+    """Uninstall on a non-SELinux host must not look for a module to remove."""
+    with (
+        patch("ttp.selinux.resolve_optional", return_value=None),
+        patch("ttp.tor_detect.is_selinux_module_installed") as mock_installed,
+        patch("ttp.selinux.subprocess.run") as mock_run,
+    ):
+        remove_selinux_module()
+
+    assert mock_run.call_count == 0
+    # The cheap check comes first: no semodule, so never ask whether it is loaded.
+    assert mock_installed.call_count == 0
+
+
+def test_remove_selinux_module_warns_but_does_not_raise_on_failure(caplog):
+    """`ttp uninstall` must finish removing everything else.
+
+    A leftover policy module is inert - it labels ports Tor is no longer using.
+    An exception here would stop the uninstall partway through, which leaves
+    things that are not inert.
+    """
+    with (
+        patch("ttp.tor_detect.is_selinux_module_installed", return_value=True),
+        patch("ttp.selinux.resolve_optional", return_value="/usr/sbin/semodule"),
+        patch(
+            "ttp.selinux.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "semodule", stderr=b"module not found"),
+        ),
+        caplog.at_level(logging.WARNING, logger="ttp"),
+    ):
+        remove_selinux_module()  # must not raise
+
+    assert "Failed to remove SELinux policy module" in caplog.text


### PR DESCRIPTION
Tier 2 of #31.

## The shape of the problem

Three modules log a warning and carry on where a teardown step fails. That is the **right** call — they run from `stop` and from `start`'s rollback, where raising would abandon every remaining step. What was untested is that *carrying on actually happens*, and "swallowed" quietly becoming "stopped" is invisible from the outside: the log line looks identical either way.

So each test breaks one step and asserts the **later** ones still ran.

## `restore_dns` — `ttp/dns.py` 77% → 100%

It unmounts the overlay, hands systemd-resolved back its configuration, and deletes the volatile file, in that order. The order is load-bearing: the unmount comes first so systemd-resolved reads the restored base file.

A teardown that gave up after a failed unmount would leave `/etc/resolv.conf` still bind-mounted onto a Tor DNSPort that `stop` is about to kill — every lookup on the host failing, no session left, and nothing connecting the two.

Also covers **`apply_dns`'s rollback of its own systemd-resolved drop-in**. That property is what lets `start`'s two DNS branches skip `restore_dns` entirely — it was asserted in a test docstring in #32 and verified nowhere. Now it is a contract, including the case where the rollback itself fails and must not mask the error that triggered it.

Along the way the rest of the module: `detect_active_interface` (its success branch was uncovered), `_is_ttp_mount` (matching on the mount point alone would make TTP unmount a *foreign* resolv.conf overlay on teardown), and the 100-attempt stale-mount warning.

## `apply_emergency_killswitch` — `ttp/firewall/emergency.py` 88% → 100%

The single highest-value uncovered block in the tree, as called in #31. The killswitch fires when the watchdog has **already** concluded integrity is lost, so the only open question is whether the caller finds out.

A swallowed exception here is the worst failure mode TTP has: the FSM transitions to `killswitch` and reports the network isolated while it is still wide open. **Fail-open, reported as fail-closed.**

- A `FirewallError` propagates as **itself**, not re-wrapped — so the operator being told the network could not be isolated still gets nft's reason.
- Anything else (`OSError`: nft missing, `/run` unwritable, tmpfs full) is wrapped in `FirewallError`, because the FSM catches that type and would otherwise miss a bare `OSError` entirely. Cause chain preserved.

## `ttp/selinux.py` 67% → 100%

`label_ports_selinux` had **no test at all**. On an enforcing host Tor cannot bind a TransPort or DNSPort that is not labelled `tor_port_t`, so a silent no-op means `ttp start` applies the full ruleset — redirecting all traffic at a port Tor could never open — and then fails verification. That is the fail-closed-but-broken state exit code 3 exists to report, reached from a policy detail rather than a network fault.

Covered:

- the `semanage port -a` → `-m` fallback. Not an edge case: the label survives a reboot, so **every session after the first** takes it.
- the per-port `try` inside the loop, so one unlabellable port does not cost the other its label.
- that the DNSPort is labelled `udp`, not `tcp` — that mutation is a DNS-only leak path that looks like a working session.
- the degrade-don't-raise contract on all four functions. They run from `setup_managed_tor` before any rule exists, so an exception would abort `start` on the one path that leaves the host in **cleartext**.

## Verification — sixteen mutations

Each swallow turned into a stop; each re-raise removed; the `-m` fallback disarmed; the DNSPort protocol flipped; the per-port `try` hoisted; the `semodule` probe reordered; `_is_ttp_mount` made to match foreign overlays; `apply_dns` made to roll back a drop-in it never wrote.

**All sixteen fail the intended test.** (The killswitch swallow fails both of its tests, correctly.)

## Numbers

| | before | after |
|---|---|---|
| `ttp/dns.py` | 77% | **100%** |
| `ttp/selinux.py` | 67% | **100%** |
| `ttp/firewall/emergency.py` | 88% | **100%** |
| total | 89% | **90.72%** |
| `COV_FAIL_UNDER` | 88 | **90** |

516 passed / 2 skipped. `make lint` clean.

## One correction to #31

The issue body said `selinux.py`'s lines 77-119 were `install_selinux_module` and put them out of scope. Both halves were wrong: there is no function by that name (it is `setup_selinux_if_needed`), and 77-119 is `label_ports_selinux` — the function with the highest-value gap in the file, not the one to skip. The genuinely expensive part (shelling out to `checkmodule`/`semodule_package`/`semodule`) is 51-70, already covered, of which only the `except` at 71-72 was missing and is a two-line test. Corrected in a comment on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FKToGVxTindAZG36nSi6G